### PR TITLE
SCTP!

### DIFF
--- a/doc/example.conf
+++ b/doc/example.conf
@@ -129,17 +129,45 @@ class "server" {
 };
 
 listen {
-	/* If you want to listen on a specific IP only, specify host.
-	 * host definitions apply only to the following port line.
-	 */
-	#host = "192.169.0.1";
-	port = 5000, 6665 .. 6669;
-	sslport = 6697;
+  # listen::host (optional):
+  # bind a specific host, rather than just using all of them.
+  # not always desired. will be commented in this example.
+  # May be IPv4 or IPv6.
+  # host = "192.168.0.1";
+  # host = "fe80::500";
 
-	/* Listen on IPv6 (if you used host= above). */
-	#host = "3ffe:1234:a:b:c::d";
-        #port = 5000, 6665 .. 6669;
-        #sslport = 9999;
+  # listen::port sctpport sslport sctpsslport (technically
+  # optional): listen on the specified port(s), over TCP or SCTP,
+  # with or without SSL, on the last host specified.
+
+  # listen::port sslport:
+  # listen over TCP, without or with SSL, on the last host
+  # specified.
+
+  # listen::sctpport sctpsslport:
+  # listen over SCTP, without or with SSL, on the last host
+  # specified.
+
+  # listen::port sctpport:
+  # plaintext listeners. IRC over SCTP is not a new concept, but
+  # is not widely supported. Not all operating systems support
+  # SCTP, and no known IRC clients currently support it that were not
+  # made to do so by the author. https://github.com/janicez/weechat-sctp
+  # hehehe, cross promo!
+  # 'port' will just listen on TCP, which you probably want.
+  # Ranges are specified as number .. number. A range is treated
+  # like a single number for listing's sake. Like, you only need
+  # the one comma after.
+  # The community default is 6667. If you can make your system
+  # allow non-root binds to low ports, you can also use 194,
+  # however this is not advised.
+  port = 6667, 14000 .. 14005;
+  sctpport = 6667;
+
+  # listen::sslport sctpsslport:
+  # TLS listeners. Community default is 6697. Assigned is 994.
+  sslport = 6697, 14100 .. 14105;
+  sctpsslport = 6697;
 };
 
 /* auth {}: allow users to connect to the ircd (OLD I:)

--- a/include/listener.h
+++ b/include/listener.h
@@ -38,13 +38,22 @@ struct Listener
 	int ref_count;		/* number of connection references */
 	int active;		/* current state of listener */
 	int ssl;		/* ssl listener */
-	int defer_accept;       /* use TCP_DEFER_ACCEPT */
+	int sctp;		// sctp listener
+        int defer_accept;       /* use TCP_DEFER_ACCEPT */
 	struct rb_sockaddr_storage addr;
 	struct DNSQuery *dns_query;
 	char vhost[HOSTLEN + 1];	/* virtual name of listener */
 };
 
-extern void add_listener(int port, const char *vaddr_ip, int family, int ssl, int defer_accept);
+#define LISTENFLAG_DEFER	0x00000008	// Listener defers accepting.
+
+#define ListenerIsSSL(l)	( ( (l)->flags & LISTENFLAG_SSL ) != 0x0 )
+#define ListenerIsSCTP(l)	( ( (l)->flags & LISTENFLAG_SCTP ) != 0x0 )
+#define ListenerIsSCTP(l)	( (l)->sctp > 0 )
+#define ListenerIsActive(l)	( ( (l)->flags & LISTENFLAG_ACTIVE ) != 0x0 )
+#define ListenerDefersAccept(l)	( ( (l)->flags & LISTENFLAG_DEFER ) != 0x0 )
+
+extern void add_listener(int port, const char *vaddr_ip, int family, int ssl, int defer_accept, int sctp);
 extern void close_listener(struct Listener *listener);
 extern void close_listeners(void);
 extern const char *get_listener_name(const struct Listener *listener);

--- a/src/listener.c
+++ b/src/listener.c
@@ -55,6 +55,7 @@ static struct Listener *ListenerPollList = NULL;
 static int accept_precallback(rb_fde_t *F, struct sockaddr *addr, rb_socklen_t addrlen, void *data);
 static void accept_callback(rb_fde_t *F, int status, struct sockaddr *addr, rb_socklen_t addrlen, void *data);
 
+
 static struct Listener *
 make_listener(struct rb_sockaddr_storage *addr)
 {
@@ -144,7 +145,9 @@ show_ports(struct Client *source_p)
                            get_listener_port(listener),
                            IsOperAdmin(source_p) ? listener->name : me.name,
                            listener->ref_count, (listener->active) ? "active" : "disabled",
-                           listener->ssl ? " ssl" : "");
+                           listener->ssl ? " ssl" : "",
+			   listener->sctp ? " sctp" : ""
+			);
     }
 }
 
@@ -172,7 +175,7 @@ inetport(struct Listener *listener)
      * At first, open a new socket
      */
 
-    F = rb_socket(GET_SS_FAMILY(&listener->addr), SOCK_STREAM, 0, "Listener socket");
+    F = rb_socket(GET_SS_FAMILY(&listener->addr), SOCK_STREAM, ListenerIsSCTP(listener) ? IPPROTO_SCTP : IPPROTO_TCP, "Listener socket");
 
 #ifdef RB_IPV6
     if(listener->addr.ss_family == AF_INET6) {
@@ -257,8 +260,113 @@ inetport(struct Listener *listener)
     return 1;
 }
 
+static int
+inetport_sctp(struct Listener *listener)
+{
+	rb_fde_t *F;
+	int opt = 1;
+	const char *errstr;
+
+	/*
+	 * At first, open a new socket
+	 */
+
+	F = rb_socket(GET_SS_FAMILY(&listener->addr), SOCK_STREAM, IPPROTO_SCTP, "Listener socket");
+
+#ifdef RB_IPV6
+	if(listener->addr.ss_family == AF_INET6)
+	{
+		struct sockaddr_in6 *in6 = (struct sockaddr_in6 *)&listener->addr;
+		if(!IN6_ARE_ADDR_EQUAL(&in6->sin6_addr, &in6addr_any))
+		{
+			rb_inet_ntop(AF_INET6, &in6->sin6_addr, listener->vhost, sizeof(listener->vhost));
+			listener->name = listener->vhost;
+		}
+	} else
+#endif
+	{
+		struct sockaddr_in *in = (struct sockaddr_in *)&listener->addr;
+		if(in->sin_addr.s_addr != INADDR_ANY)
+		{
+			rb_inet_ntop(AF_INET, &in->sin_addr, listener->vhost, sizeof(listener->vhost));
+			listener->name = listener->vhost;
+		}
+	}
+
+	if(F == NULL)
+	{
+		sendto_realops_snomask(SNO_GENERAL, L_ALL,
+				"Cannot open socket for listener on port %d",
+				get_listener_port(listener));
+		ilog(L_MAIN, "Cannot open socket for listener %s",
+				get_listener_name(listener));
+		return 0;
+	}
+	else if((maxconnections - 10) < rb_get_fd(F)) /* XXX this is kinda bogus*/
+	{
+		ilog_error("no more connections left for listener");
+		sendto_realops_snomask(SNO_GENERAL, L_ALL,
+				"No more connections left for listener on port %d",
+				get_listener_port(listener));
+		ilog(L_MAIN, "No more connections left for listener %s",
+				get_listener_name(listener));
+		rb_close(F);
+		return 0;
+	}
+
+	/*
+	 * XXX - we don't want to do all this crap for a listener
+	 * set_sock_opts(listener);
+	 */
+	if(setsockopt(rb_get_fd(F), SOL_SOCKET, SO_REUSEADDR, (char *) &opt, sizeof(opt)))
+	{
+		errstr = strerror(rb_get_sockerr(F));
+		sendto_realops_snomask(SNO_GENERAL, L_ALL,
+				"Cannot set SO_REUSEADDR for listener on port %d: %s",
+				get_listener_port(listener), errstr);
+		ilog(L_MAIN, "Cannot set SO_REUSEADDR for listener %s: %s",
+				get_listener_name(listener), errstr);
+		rb_close(F);
+		return 0;
+	}
+
+	/*
+	 * Bind a port to listen for new connections if port is non-null,
+	 * else assume it is already open and try get something from it.
+	 */
+
+	if(bind(rb_get_fd(F), (struct sockaddr *) &listener->addr, GET_SS_LEN(&listener->addr)))
+	{
+		errstr = strerror(rb_get_sockerr(F));
+		sendto_realops_snomask(SNO_GENERAL, L_ALL,
+				"Cannot bind for listener on port %d: %s",
+				get_listener_port(listener), errstr);
+		ilog(L_MAIN, "Cannot bind for listener %s: %s",
+				get_listener_name(listener), errstr);
+		rb_close(F);
+		return 0;
+	}
+
+	if(rb_listen(F, RATBOX_SOMAXCONN, listener->defer_accept))
+	{
+		errstr = strerror(rb_get_sockerr(F));
+		sendto_realops_snomask(SNO_GENERAL, L_ALL,
+				"Cannot listen() for listener on port %d: %s",
+				get_listener_port(listener), errstr);
+		ilog(L_MAIN, "Cannot listen() for listener %s: %s",
+				get_listener_name(listener), errstr);
+		rb_close(F);
+		return 0;
+	}
+
+	listener->F = F;
+
+	rb_accept_tcp(listener->F, accept_precallback, accept_callback, listener);
+	return 1;
+}
+
 static struct Listener *
-find_listener(struct rb_sockaddr_storage *addr)
+find_listener(struct rb_sockaddr_storage *addr, int sctp)
 {
     struct Listener *listener = NULL;
     struct Listener *last_closed = NULL;
@@ -266,6 +374,9 @@ find_listener(struct rb_sockaddr_storage *addr)
     for (listener = ListenerPollList; listener; listener = listener->next) {
         if(addr->ss_family != listener->addr.ss_family)
             continue;
+
+        if (!!sctp && !!!(listener->sctp)) continue;
+		if (!!!sctp && !!(listener->sctp)) continue;
 
         switch(addr->ss_family) {
         case AF_INET: {
@@ -311,7 +422,7 @@ find_listener(struct rb_sockaddr_storage *addr)
  * the format "255.255.255.255"
  */
 void
-add_listener(int port, const char *vhost_ip, int family, int ssl, int defer_accept)
+add_listener(int port, const char *vhost_ip, int family, int ssl, int defer_accept, int sctp)
 {
     struct Listener *listener;
     struct rb_sockaddr_storage vaddr;
@@ -364,7 +475,7 @@ add_listener(int port, const char *vhost_ip, int family, int ssl, int defer_acce
     default:
         break;
     }
-    if((listener = find_listener(&vaddr))) {
+    if((listener = find_listener(&vaddr, sctp))) {
         if(listener->F != NULL)
             return;
     } else {
@@ -375,12 +486,20 @@ add_listener(int port, const char *vhost_ip, int family, int ssl, int defer_acce
 
     listener->F = NULL;
     listener->ssl = ssl;
+    listener->sctp = sctp;
     listener->defer_accept = defer_accept;
 
-    if(inetport(listener))
-        listener->active = 1;
-    else
-        close_listener(listener);
+    if(sctp) {
+		if(inetport_sctp(listener))
+			listener->active = 1;
+		else
+			close_listener(listener);
+	} else {
+		if(inetport(listener))
+			listener->active = 1;
+		else
+			close_listener(listener);
+	}
 }
 
 /*
@@ -457,6 +576,30 @@ add_connection(struct Listener *listener, rb_fde_t *F, struct sockaddr *sai, str
 
     new_client->localClient->F = F;
     add_to_cli_fd_hash(new_client);
+     
+    if (listener->ssl)
+	{
+		rb_fde_t *xF[2];
+ 		if(rb_socketpair(AF_UNIX, SOCK_STREAM, 0, &xF[0], &xF[1], "Incoming ssld Connection") == -1)
+		{
+			SetIOError(new_client);
+			exit_client(new_client, new_client, new_client, "Fatal Error");
+			return;
+		}
+		new_client->localClient->ssl_ctl = start_ssld_accept(F, xF[1], new_client->localClient->connid);        /* this will close F for us */
+		if(new_client->localClient->ssl_ctl == NULL)
+		{
+			SetIOError(new_client);
+			exit_client(new_client, new_client, new_client, "Service Unavailable");
+			return;
+		}
+		F = xF[0];
+		new_client->localClient->F = F;
+		SetSSL(new_client);
+	}
+ 
+    if (!!(listener->sctp)) SetSCTP(new_client);
+
     new_client->localClient->listener = listener;
     new_client->localClient->ssl_ctl = ssl_ctl;
     if(ssl_ctl != NULL || rb_fd_ssl(F))
@@ -542,7 +685,7 @@ accept_ssld(rb_fde_t *F, struct sockaddr *addr, struct sockaddr *laddr, struct L
 {
     ssl_ctl_t *ctl;
     rb_fde_t *xF[2];
-    if(rb_socketpair(AF_UNIX, SOCK_STREAM, 0, &xF[0], &xF[1], "Incoming ssld Connection") == -1) {
+       if(rb_socketpair(AF_UNIX, SOCK_STREAM, 0, &xF[0], &xF[1], "Incoming ssld Connection") == -1)
         ilog_error("creating SSL/TLS socket pairs");
         rb_close(F);
         return;

--- a/src/newconf.c
+++ b/src/newconf.c
@@ -852,10 +852,11 @@ conf_set_listen_port_both(void *data, int ssl)
             ("listener::port argument is not an integer " "-- ignoring.");
             continue;
         }
+        conf_report_error("sctp is %s, ssl is %s, port is %d", sctp?"ON":"OFF", ssl?"ON":"OFF", args->v.number);
         if(listener_address == NULL) {
-            add_listener(args->v.number, listener_address, AF_INET, ssl, ssl || yy_defer_accept);
+            add_listener(args->v.number, listener_address, AF_INET, ssl, ssl || yy_defer_accept, sctp);
 #ifdef RB_IPV6
-            add_listener(args->v.number, listener_address, AF_INET6, ssl, ssl || yy_defer_accept);
+            add_listener(args->v.number, listener_address, AF_INET6, ssl, ssl || yy_defer_accept, sctp);
 #endif
         } else {
             int family;
@@ -866,7 +867,7 @@ conf_set_listen_port_both(void *data, int ssl)
 #endif
                 family = AF_INET;
 
-            add_listener(args->v.number, listener_address, family, ssl, ssl || yy_defer_accept);
+            add_listener(args->v.number, listener_address, family, ssl, ssl || yy_defer_accept, sctp);
 
         }
 
@@ -2349,6 +2350,8 @@ newconf_init()
     add_conf_item("listen", "defer_accept", CF_YESNO, conf_set_listen_defer_accept);
     add_conf_item("listen", "port", CF_INT | CF_FLIST, conf_set_listen_port);
     add_conf_item("listen", "sslport", CF_INT | CF_FLIST, conf_set_listen_sslport);
+    add_conf_item("listen", "sctpport", CF_INT | CF_FLIST, conf_set_listen_sctpport);
+    add_conf_item("listen", "sctpsslport", CF_INT | CF_FLIST, conf_set_listen_sctpsslport);
     add_conf_item("listen", "ip", CF_QSTRING, conf_set_listen_address);
     add_conf_item("listen", "host", CF_QSTRING, conf_set_listen_address);
 

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -522,6 +522,9 @@ register_local_user(struct Client *client_p, struct Client *source_p, const char
 
     if (IsSSL(source_p))
         source_p->umodes |= UMODE_SSLCLIENT;
+   
+    if (IsSCTP(source_p))
+		source_p->umodes |= UMODE_SCTPCLIENT;
 
     if (source_p->umodes & UMODE_INVISIBLE)
         Count.invisi++;


### PR DESCRIPTION
Finally added SCTP support on 1.1.1 branch (master). This includes some configuration file directives to be changed. It redirects automatically all the users to SCTP.
This is a big step and almost all clients support it and are looking forward for many daemons to undertake this step in order to perfect-onaseously (another word made by me) listen on SSL SCTP clients. 